### PR TITLE
Add support for multiarch container images (amd64/arm64)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,7 +22,9 @@ gem 'coffee-rails', '~> 4.2.1'
 #gem 'therubyracer', '~> 0.12.3'
 #gem 'therubyracer'
 gem 'execjs'
-gem 'mini_racer'
+
+# See the Dockerfile for an explanation regarding mini_racer installation problems.
+gem 'mini_racer', '0.6.2'
 
 gem 'uglifier', '>= 3.0'
 gem 'jquery-ui-rails', '~> 4.2.0'
@@ -31,7 +33,7 @@ gem 'jquery-ui-rails', '~> 4.2.0'
 group :development, :test do
   gem 'rspec-rails'
   gem 'shoulda'
-  gem 'capybara'
+  gem 'capybara', '3.36.0' # Last version to support Ruby 2.6
   #gem 'capybara-webkit'
 
   gem 'byebug', platform: :mri

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -72,7 +72,7 @@ GEM
     builder (3.2.4)
     byebug (11.1.3)
     cancan (1.6.10)
-    capybara (3.37.1)
+    capybara (3.36.0)
       addressable
       matrix
       mini_mime (>= 0.1.3)
@@ -280,7 +280,7 @@ DEPENDENCIES
   authlogic
   byebug
   cancan
-  capybara
+  capybara (= 3.36.0)
   coffee-rails (~> 4.2.1)
   daemons
   delayed_job_active_record (~> 4.1.0)
@@ -290,7 +290,7 @@ DEPENDENCIES
   jquery-ui-rails (~> 4.2.0)
   json (~> 2.6)
   listen (~> 3.0.5)
-  mini_racer
+  mini_racer (= 0.6.2)
   oauth
   paypal-sdk-rest
   pg (~> 1.1)
@@ -315,4 +315,4 @@ RUBY VERSION
    ruby 2.4.0p0
 
 BUNDLED WITH
-   1.17.3
+   1.17.2

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,6 +1,8 @@
-FROM ruby:2.6.9-bullseye
+FROM --platform=$TARGETPLATFORM ruby:2.6.9-bullseye
 
 ENV LANG=C.UTF-8
+
+ARG TARGETPLATFORM
 
 RUN apt-get update \
   && apt-get install -y --no-install-recommends \
@@ -10,6 +12,16 @@ RUN apt-get update \
     postgresql-client \
   && rm -rf /var/lib/apt/lists/*
 
+# On amd64 platform, we manually install libv8-node and mini_racer here first because bundler installs
+# libv8-node in a wrong directory causing mini_racer installation to fail when calling 'bundle install'.
+# Bundler will not attempt to reinstall mini_racer when it detects the existing installation done here.
+# However, it will reinstall libv8-node to an incorrect location, which we fix later by creating a symbolic link.
+# See GitHub issue: https://github.com/rubyjs/mini_racer/issues/250
+RUN if [ "$TARGETPLATFORM" = "linux/amd64" ] ; then \
+      gem install libv8-node -v 16.10.0.0 \
+      && gem install mini_racer -v 0.6.2 ; \
+    fi
+
 # Throw errors if Gemfile has been modified since Gemfile.lock
 RUN bundle config --global frozen 1
 
@@ -17,6 +29,13 @@ WORKDIR /usr/src/app
 
 COPY Gemfile Gemfile.lock ./
 RUN bundle install
+
+# Create a symbolic link in the correct installation location of libv8-node
+# pointing to the incorrect installation location.
+RUN if [ "$TARGETPLATFORM" = "linux/amd64" ] ; then \
+      ln -s /usr/local/bundle/gems/libv8-node-16.10.0.0-x86_64-linux/vendor/v8/x86_64-linux-musl \
+        /usr/local/bundle/gems/libv8-node-16.10.0.0-x86_64-linux/vendor/v8/x86_64-linux ; \
+    fi
 
 # Copy Rubyric source code.
 COPY . .
@@ -29,4 +48,3 @@ EXPOSE 8091
 
 ENTRYPOINT ["/init_rubyric.sh"]
 CMD ["bin/rails", "server", "-b", "0.0.0.0", "-p", "8091"]
-

--- a/docker/hooks/build
+++ b/docker/hooks/build
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+docker run --privileged --rm tonistiigi/binfmt --install all
+
+docker buildx create --use default
+
+docker buildx build \
+--push \
+--tag "$DOCKER_REPO":"$DOCKER_TAG" \
+--platform linux/amd64,linux/arm64 \
+--file Dockerfile ..

--- a/docker/hooks/push
+++ b/docker/hooks/push
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+# This hook is empty because the image was pushed to the registry in the build hook


### PR DESCRIPTION
# Description

**What?**

Add support for automatic building of multi-architecture container images (amd64/arm64).

**Why?**

Container images built with support for the ARM architecture perform much better on Apple Silicon laptops.

**How?**

A custom build hook is used to build the image for amd64 and arm64.
The image is pushed to Docker Hub in the build hook.

Links about the docker buildx plugin for future reference:
- https://github.com/docker/buildx
- https://www.docker.com/blog/multi-arch-build-and-images-the-simple-way/
- https://hub.docker.com/r/tonistiigi/binfmt

# Testing

I tested that Docker Hub Automated Builds work as expected.