### PR TITLE
Add warnings for ambiguous / unknown reviewers in batch upload

### DIFF
--- a/app/controllers/course_instances/groups_controller.rb
+++ b/app/controllers/course_instances/groups_controller.rb
@@ -64,10 +64,17 @@ class CourseInstances::GroupsController < GroupsController
     @course_instance = CourseInstance.find(params[:course_instance_id])
     load_course
     authorize! :update, @course_instance
+
+    @reported_ambiguous_keys = []
+    @reviewers_not_found = []
     
     if params[:paste]
-      @course_instance.batch_create_groups(params[:paste])
-      redirect_to course_instance_groups_path
+      batch_create_groups_errors = @course_instance.batch_create_groups(params[:paste])
+      @reported_ambiguous_keys = batch_create_groups_errors[:reported_ambiguous_keys]
+      @reviewers_not_found = batch_create_groups_errors[:reviewers_not_found]
+      if @reported_ambiguous_keys.empty? and @reviewers_not_found.empty?
+        redirect_to course_instance_groups_path
+      end
       log "batch_groups upload"
     else
       log "batch_groups view"

--- a/app/views/course_instances/groups/batch.html.erb
+++ b/app/views/course_instances/groups/batch.html.erb
@@ -10,6 +10,32 @@
   </ul>
 </div>
 
+<!-- Warning message if there are errors creating any of the listed groups -->
+<% unless @reported_ambiguous_keys.empty? and @reviewers_not_found.empty? %>
+<div class="alert alert-danger">
+  <p>Some groups were successfully created, but there were some errors - see details below.</p>
+  <!-- Warning message if there are ambiguous keys -->
+  <% unless @reported_ambiguous_keys.empty? %>
+  The following reviewer identifiers were ambiguous, e.g. they matched multiple accounts. Their assignments need to be manually created.
+  <% @reported_ambiguous_keys.each do |key| %>
+  <div>
+    <%= key %>
+  </div>
+  <% end %>
+  <% end %>
+
+  <!-- Warning message if any reviewers are not found -->
+  <% unless @reviewers_not_found.empty? %>
+  The following reviewers were not found.
+  <% @reviewers_not_found.each do |key| %>
+  <div>
+    <%= key %>
+  </div>
+  <% end %>
+  <% end %>
+</div>
+<% end %>
+
 <%= form_tag batch_course_instance_groups_path(@course_instance), html: { multipart: true } do |f| -%>
   <div class="hint">
     Paste the student list here to create groups and/or assign groups to reviewers


### PR DESCRIPTION
# Description

**What?**

Added warning messages when some of the reviewers in an uploaded batch group list are ambiguous e.g. there are multiple matches for their keys, or when reviewers with given keys are not found.

Also removed a check that skipped reviewers with lti_user_id - if there are LTI users that also have non-lti accounts with the same identifiers, they'll be skipped when the actual assigning of reviewers is done anyway. The old functionality prevented LTI users from being assigned even if their identifiers were unique. The commit which added this functionality (https://github.com/apluslms/rubyric/commit/00a811e07b9c43349cbac607dd80e1f8f6d46dac) doesn't have details on what kind of issues there were with LTI users, though.

**Why?**

LTI users were unable to be assigned as reviewers, and no error messages were given, causing confusion.

**How?**

Removed a check that skipped LTI users when collecting reviewers. Now if there are any errors with ambiguous reviewer keys or some reviewers aren't found, the user is returned to the batch upload page with an error message with a list of reviewer keys that were unable to be processed.

# Testing

**What type of test did you run?**

- [X] Manual testing.

Created a mixture of LTI and non LTI users and tried uploading various group combinations.

**Did you test the changes in**

- [X] Firefox